### PR TITLE
Validate strings with blank spaces in comments to avoid empty comments

### DIFF
--- a/src/components/comments/Comments.jsx
+++ b/src/components/comments/Comments.jsx
@@ -17,7 +17,7 @@ const Comments = ({ postId, commentsCount, setCommentsCount }) => {
     const onContentsChange = event => {
       let newContents = event.target.value;
       setContents(newContents)
-      setBtnEnabled(newContents && newContents.length > 0)
+      setBtnEnabled(newContents && newContents.trim().length > 0)
     }
 
     const setSaving = (saving) => {


### PR DESCRIPTION
This PR includes a small fix to avoid blank comments in social.point